### PR TITLE
Fix tests in travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,6 @@ solution: OpenRMS.sln
 branches:
   only:
     - master-net-core
-before_install:
-  - sudo apt-get install nunit-console
 before_script:
   - chmod +x build.sh
   - chmod +x run-tests.sh

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,1 +1,1 @@
-nunit-console Code/Shared/ORMS.Shared.SharedKernel.UnitTests/bin/Release/netcoreapp2.0/ORMS.Shared.SharedKernel.UnitTests.dll
+dotnet test -c Release --no-build --no-restore Code/Shared/ORMS.Shared.SharedKernel.UnitTests/ORMS.Shared.SharedKernel.UnitTests.csproj


### PR DESCRIPTION
Uses `dotnet test` instead of nunit console runner.